### PR TITLE
Conexão com API do IBGE para limpar nome das cidades na coleta

### DIFF
--- a/crawler/api_client.py
+++ b/crawler/api_client.py
@@ -1,0 +1,37 @@
+import json
+
+import requests
+from requests.exceptions import ConnectionError
+
+
+def try_connection(access):
+    def wrapper(*args, **kwargs):
+        try:
+            return access(*args, **kwargs)
+        except ConnectionError as conn_error:
+            return (
+                conn_error.request.text,
+                conn_error.request.status_code,
+            )
+
+    return wrapper
+
+
+class APIClient:
+    headers = {"content-type": "application/json"}
+
+    def __init__(self, connection_class, conn_timeout=60):
+        self.connection_class = connection_class
+        self.conn_timeout = conn_timeout
+
+    @try_connection
+    def http_request(self, url, method_http, request_data={}):
+        response_data = requests.request(
+            method=method_http,
+            url=url,
+            data=json.dumps(request_data),
+            headers=self.headers,
+            timeout=self.conn_timeout,
+        )
+
+        return response_data.json()

--- a/crawler/clients/ibge.py
+++ b/crawler/clients/ibge.py
@@ -1,0 +1,44 @@
+import re
+
+from crawler.api_client import APIClient
+from crawler.connections import IBGEConnection
+
+
+class APIClientIBGE(APIClient):
+    def __init__(self, uf=None, city=None):
+        super().__init__(IBGEConnection)
+        self.states = self.get_states(uf)
+        self.cities = self.get_cities(self.states["id"], city) if self.states else []
+
+    def get_states(self, uf=None):
+        """
+        Request in states list
+        """
+        data_response = self.http_request(IBGEConnection.URL_STATES, "get")
+
+        return (
+            next((item for item in data_response if item["nome"] == uf), None)
+            if uf
+            else data_response
+        )
+
+    def get_cities(self, uf, city=None):
+        """
+        Request in cities list
+        """
+        data_response = self.http_request(
+            IBGEConnection.URL_CITIES.format(uf=uf), "get"
+        )
+
+        return self.search_city(city, data_response) if city else data_response
+
+    def search_city(self, city, data=None):
+        data_response = data if data else self.cities
+        return next(
+            (
+                item
+                for item in data_response
+                if re.search(item["nome"], city, re.IGNORECASE)
+            ),
+            None,
+        )

--- a/crawler/connections.py
+++ b/crawler/connections.py
@@ -1,0 +1,14 @@
+"""
+    Connections Class for APIClients
+"""
+
+
+class IBGEConnection:
+    URL_STATES = "https://servicodados.ibge.gov.br/api/v1/localidades/estados/"
+    URL_CITIES = (
+        "https://servicodados.ibge.gov.br/api/v1/localidades/estados/{uf}/municipios/"
+    )
+
+    _connection_error_messages = {
+        "connection_error": "Não foi possível estabeler uma conexão com o sistema do IBGE"
+    }

--- a/poetry.lock
+++ b/poetry.lock
@@ -104,6 +104,14 @@ version = "1.0.7"
 
 [[package]]
 category = "main"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+python-versions = "*"
+version = "2020.4.5.1"
+
+[[package]]
+category = "main"
 description = "Foreign Function Interface for Python calling C code."
 name = "cffi"
 optional = false
@@ -112,6 +120,14 @@ version = "1.14.0"
 
 [package.dependencies]
 pycparser = "*"
+
+[[package]]
+category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+python-versions = "*"
+version = "3.0.4"
 
 [[package]]
 category = "dev"
@@ -307,7 +323,7 @@ version = "2.9"
 [[package]]
 category = "dev"
 description = "Read metadata from Python packages"
-marker = "python_version >= \"3.5\" and python_version < \"3.8\" or python_version < \"3.8\""
+marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
@@ -691,7 +707,6 @@ test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 [[package]]
 category = "dev"
 description = "Python parsing module"
-marker = "python_version >= \"3.5\""
 name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
@@ -807,6 +822,24 @@ name = "regex"
 optional = false
 python-versions = "*"
 version = "2020.4.4"
+
+[[package]]
+category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.23.0"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<4"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
 category = "main"
@@ -981,6 +1014,19 @@ version = "3.7.4.2"
 
 [[package]]
 category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.25.9"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+
+[[package]]
+category = "main"
 description = "Library of web-related functions"
 name = "w3lib"
 optional = false
@@ -1017,7 +1063,7 @@ brotli = ["brotli"]
 [[package]]
 category = "dev"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version >= \"3.5\" and python_version < \"3.8\""
+marker = "python_version >= \"3.5\" and python_version < \"3.8\" or python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
@@ -1044,7 +1090,7 @@ test = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [metadata]
-content-hash = "3e58be65583ab90d8600b0be29e66a3ed6482145d60033eb88ca01af45eedaf4"
+content-hash = "15cef4d647fdf18ce51b50204efef9f5b4ac1520ca49648e08566661119ada69"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -1115,6 +1161,10 @@ brotli = [
     {file = "Brotli-1.0.7-cp38-cp38-win_amd64.whl", hash = "sha256:f9ee88bb52352588ceb811d045b5c9bb1dc38927bc150fd156244f60ff3f59f1"},
     {file = "Brotli-1.0.7.zip", hash = "sha256:0538dc1744fd17c314d2adc409ea7d1b779783b89fd95bcfb0c2acc93a6ea5a7"},
 ]
+certifi = [
+    {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},
+    {file = "certifi-2020.4.5.1.tar.gz", hash = "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"},
+]
 cffi = [
     {file = "cffi-1.14.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384"},
     {file = "cffi-1.14.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30"},
@@ -1144,6 +1194,10 @@ cffi = [
     {file = "cffi-1.14.0-cp38-cp38-win32.whl", hash = "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8"},
     {file = "cffi-1.14.0-cp38-cp38-win_amd64.whl", hash = "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b"},
     {file = "cffi-1.14.0.tar.gz", hash = "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6"},
+]
+chardet = [
+    {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
+    {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
 click = [
     {file = "click-7.1.1-py2.py3-none-any.whl", hash = "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"},
@@ -1538,6 +1592,10 @@ regex = [
     {file = "regex-2020.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3"},
     {file = "regex-2020.4.4.tar.gz", hash = "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142"},
 ]
+requests = [
+    {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
+    {file = "requests-2.23.0.tar.gz", hash = "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"},
+]
 restless = [
     {file = "restless-2.1.1.tar.gz", hash = "sha256:f66b590cd1a248fd60a7f6540dff318a180bcbf073eefa16ac5ea978c161087b"},
 ]
@@ -1626,6 +1684,10 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.2-py2-none-any.whl", hash = "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"},
     {file = "typing_extensions-3.7.4.2-py3-none-any.whl", hash = "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5"},
     {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
+]
+urllib3 = [
+    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
+    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
 w3lib = [
     {file = "w3lib-1.21.0-py2.py3-none-any.whl", hash = "sha256:847704b837b2b973cddef6938325d466628e6078266bc2e1f7ac49ba85c34823"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ python-decouple = "^3.3"
 restless = "^2.1.1"
 scrapy = "^2.0.1"
 whitenoise = {extras = ["brotli"], version = "^5.0.1"}
+requests = "^2.23.0"
 
 [tool.poetry.dev-dependencies]
 createnv = "^0.0.1"


### PR DESCRIPTION
Optei por criar uma classe `APIClient` que faz toda a parte que é comum ao utilizar o `requests`, assim quando for criar uma classe para consumir outras API (segurança publica, secretarias estaduais, ongs, etc) basta criar a classe para essa API.

A classe `APIClientIBGE` foi criado para consumir recursos do IBGE e assim poder listar os estados e municípios, então o `ParanaSpider` (ou qualquer outra classe que precisar dessa API) basta instanciar e passar os parâmetros necessários (no caso os municípios do "**Paraná**").

Utilizo o `re.search` para buscar o município correspondente na `string` que foi realizado a raspagem, essa implementação está `search_city` da classe `APIClientIBGE`

Obs: a API do IBGE possui diversas informações que pode ser utilizado para adicionar informação mais completa no futuro.

a saída para o `last_seen_at` está da seguinte maneira agora `{nome do municipio} - {sigla do estado}`
